### PR TITLE
Typo in one of the test apps

### DIFF
--- a/t/lib/TestAppBase.pm
+++ b/t/lib/TestAppBase.pm
@@ -55,7 +55,7 @@ after 'setup_components' => sub {
         into => $app,
         component => 'TestAppBase::View::HTML',
         as => 'HTML',
-    ) unless $app->controller('HTML');
+    ) unless $app->view('HTML');
 };
 
 1;


### PR DESCRIPTION
Found this when testing against catalyst-runtime's gsoc_breadboard branch.
