### PR TITLE
Fix RT#90997 Class::MOP::load_class deprecation warnings

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,8 @@ requires 'HTML::FormHandler' => '0.28001';
 requires 'namespace::autoclean';
 requires 'Catalyst::Plugin::Session' => '0.27'; # Required as we use the 'Plugin::Session' config key in ::Manual
 
-test_requires 'Test::More' => '0.94';
+test_requires 'Test::More'  => '0.94';
+test_requires 'Class::Load' => '0.20';
 test_requires 'Test::Exception';
 test_requires 'File::Temp';
 test_requires 'Catalyst::Action::RenderView';

--- a/t/08-dbic-mappedfields.t
+++ b/t/08-dbic-mappedfields.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
-use Class::MOP;
+use Class::Load;
 use HTTP::Request::Common;
 use FindBin qw/$Bin/;
 use lib "$Bin/lib";
@@ -15,7 +15,7 @@ BEGIN {
     /;
     plan skip_all => "One of the required classes for this test $@ (" . join(',', @needed) . ") not found."
         unless eval {
-            Class::MOP::load_class($_) for @needed; 1;
+            Class::Load::load_class($_) for @needed; 1;
         };
     plan skip_all => 'Test needs ' . DBIx::Class::Optional::Dependencies->req_missing_for('admin')
         unless DBIx::Class::Optional::Dependencies->req_ok_for('admin');


### PR DESCRIPTION
This fixes RT#90997: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90997
