### PR TITLE
Bfwg/reduce test dependencies

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  * Remove test dependency on Session::Store::File
+
 0.18 Sat, 21 July 2012 14:39:00 +0100
   * Stop depending on the now unused Catalyst::Controller::ActionRole
     RT#78500

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,6 @@ test_requires 'Test::Exception';
 test_requires 'File::Temp';
 test_requires 'Catalyst::Action::RenderView';
 test_requires 'Catalyst::Plugin::Session::State::Cookie';
-test_requires 'Catalyst::Plugin::Session::Store::File';
 test_requires 'HTTP::Request::Common';
 test_requires 'Catalyst::ActionRole::ACL';
 test_requires 'CatalystX::InjectComponent';

--- a/t/lib/TestAppBase.pm
+++ b/t/lib/TestAppBase.pm
@@ -8,7 +8,7 @@ use Catalyst qw/
     +CatalystX::SimpleLogin
     Authentication
     Session
-    Session::Store::File
+    Session::Store::Dummy
     Session::State::Cookie
 /;
 extends 'Catalyst';


### PR DESCRIPTION
The module Session::Store::File isn't generally used in our applications but it's dependency on Cache::Cache causes us occasional test failures so it would be simpler to not install it.  Replacing File with Dummy appears to allow your tests to work fine without requiring any unnecessary plugins to be installed.