### PR TITLE
Fix "remember" checkbox

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,5 @@
   * Remove test dependency on Session::Store::File
+  * Fix "remember" checkbox (Yaroslav Polyakov)
 
 0.18 Sat, 21 July 2012 14:39:00 +0100
   * Stop depending on the now unused Catalyst::Controller::ActionRole

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,7 +23,7 @@ requires 'MooseX::RelatedClassRoles' => '0.004';
 requires 'Moose::Autobox';
 requires 'HTML::FormHandler' => '0.28001';
 requires 'namespace::autoclean';
-requires 'Catalyst::Plugin::Session' => '0.27'; # Required as we use the 'Plugin::Session' config key in ::Manual
+requires 'Catalyst::Plugin::Session' => '0.35'; # Required as we use the 'Plugin::Session' config key in ::Manual
 
 test_requires 'Test::More'  => '0.94';
 test_requires 'Class::Load' => '0.20';

--- a/lib/CatalystX/SimpleLogin/Controller/Login.pm
+++ b/lib/CatalystX/SimpleLogin/Controller/Login.pm
@@ -103,7 +103,7 @@ sub login
 
     if( $form->process(ctx => $ctx, params => $p) ) {
         $self->do_post_login_redirect($ctx);
-        $ctx->extend_session_expires(999999999999)
+        $ctx->change_session_expires(999999999)
             if $form->field( 'remember' )->value;
     }
 

--- a/lib/CatalystX/SimpleLogin/Controller/Login.pm
+++ b/lib/CatalystX/SimpleLogin/Controller/Login.pm
@@ -102,9 +102,16 @@ sub login
     my $p = $ctx->req->parameters;
 
     if( $form->process(ctx => $ctx, params => $p) ) {
+        my $expire = $form->field( 'remember' )->value ?
+            999999999 : $ctx->initial_session_expires - time();
+        # set expiry time in storage
+        $ctx->change_session_expires($expire);
+        # refresh changed expiry time from storage
+        $ctx->reset_session_expires;
+        # update cookie TTL
+        $ctx->set_session_id($ctx->sessionid);
+
         $self->do_post_login_redirect($ctx);
-        $ctx->change_session_expires(999999999)
-            if $form->field( 'remember' )->value;
     }
 
     $ctx->stash(


### PR DESCRIPTION
According to Catalyst::Plugin::Session documentation, extend_session_expires "... is *not* used to give an individual user a longer session." change_session_expires is intended for it.
Decrease "permanent" session to ~32 years.